### PR TITLE
5 compile/build

### DIFF
--- a/app/src/main/java/kth_a2_continuous_integration/CommandLine.java
+++ b/app/src/main/java/kth_a2_continuous_integration/CommandLine.java
@@ -7,6 +7,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 
 public class CommandLine {
+
+    /**
+     * The function executes a console/terminal command and returns the text output as a string.
+     * Designed to work on unix based and windows systems.
+     * @param command
+     * @param path
+     * @return String: Console output
+     * @throws IOException
+     */
     public static String exec(String command, String path) throws IOException {
         Process process;
         String os = System.getProperty("os.name").toLowerCase();

--- a/app/src/main/java/kth_a2_continuous_integration/CommandLine.java
+++ b/app/src/main/java/kth_a2_continuous_integration/CommandLine.java
@@ -1,0 +1,13 @@
+package kth_a2_continuous_integration;
+
+import java.io.File;
+import java.io.IOException;
+
+public class CommandLine {
+    public static void exec(String command, String path) throws IOException {
+        Process process;
+        String os = System.getProperty("os.name").toLowerCase();
+        if("windows 10".equals(os)) process = Runtime.getRuntime().exec(new String[]{"cmd.exe", "/c", command}, null, new File(path));
+        else                        process = Runtime.getRuntime().exec(new String[]{"bin/sh", "-c", command}, null, new File(path));
+    }
+}

--- a/app/src/main/java/kth_a2_continuous_integration/CommandLine.java
+++ b/app/src/main/java/kth_a2_continuous_integration/CommandLine.java
@@ -1,13 +1,32 @@
 package kth_a2_continuous_integration;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 public class CommandLine {
-    public static void exec(String command, String path) throws IOException {
+    public static String exec(String command, String path) throws IOException {
         Process process;
         String os = System.getProperty("os.name").toLowerCase();
         if("windows 10".equals(os)) process = Runtime.getRuntime().exec(new String[]{"cmd.exe", "/c", command}, null, new File(path));
         else                        process = Runtime.getRuntime().exec(new String[]{"bin/sh", "-c", command}, null, new File(path));
+
+        return output(process.getInputStream());
+    }
+
+    private static String output(InputStream iStream) {
+        String msg = "";
+        try {
+            BufferedReader bReader = new BufferedReader(new InputStreamReader(iStream));
+            String line;
+            while((line = bReader.readLine()) != null) {
+                msg += line + "\n";
+            }
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+        return msg;
     }
 }

--- a/app/src/main/java/kth_a2_continuous_integration/ContinuousIntegrationServer.java
+++ b/app/src/main/java/kth_a2_continuous_integration/ContinuousIntegrationServer.java
@@ -37,7 +37,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
         // for example
         // 1st clone your repository
         // 2nd compile the code
-
+        //String msg = CommandLine.exec(command, path name);
+        
         response.getWriter().println("CI job done");
     }
  


### PR DESCRIPTION
Commands can now be executed programatically through CommandLine.exec(command, path). This can be used to compile and run the code using gradlew build/run and knowing the path. I've only tested it so far for windows but should work with linux and other unix based systems. It returns a string with the console output.